### PR TITLE
Allow deferred configuration of tasks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'idea'
 
 group = 'net.gvmtool'
 archivesBaseName = 'gradle-sdkvendor-plugin'
-version = '0.3.1'
+version = '0.4-SNAPSHOT'
 
 sourceCompatibility = "1.6"
 targetCompatibility= "1.6"

--- a/src/main/groovy/net/gvmtool/vendors/GvmAnnounceVersionTask.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/GvmAnnounceVersionTask.groovy
@@ -6,20 +6,20 @@ class GvmAnnounceVersionTask extends GvmVendorBaseTask {
 
     static final String ANNOUNCE_ENDPOINT = "/announce/struct"
 
+    String hashtag
+
     GvmAnnounceVersionTask() {
         description = "Announce a Release on GVM."
     }
 
     @Override
-    void execute(GvmExtension config) {
-        withConnection(config.api) {
-            logger.quiet("Announcing for $config.candidate $config.version...")
+    void executeTask() {
+        withConnection(apiUrl) {
+            logger.quiet("Announcing for $candidate $version...")
 
-            def values = [candidate: config.candidate, version: config.version,
-                    hashtag: config.hashtag ?: config.candidate ]
+            def values = [candidate: candidate, version: version, hashtag: hashtag ?: candidate ]
 
-            def response = post(restClient, ANNOUNCE_ENDPOINT,
-                    config.consumerKey, config.consumerToken, values)
+            def response = post(restClient, ANNOUNCE_ENDPOINT, consumerKey, consumerToken, values)
 
             logger.quiet("Response: ${response.statusCode}: ${response.contentAsString}...")
         }

--- a/src/main/groovy/net/gvmtool/vendors/GvmDefaultVersionTask.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/GvmDefaultVersionTask.groovy
@@ -11,14 +11,14 @@ class GvmDefaultVersionTask extends GvmVendorBaseTask {
     }
 
     @Override
-    void execute(GvmExtension config) {
-        withConnection(config.api) {
-            logger.quiet("Releasing $config.candidate $config.version...")
+    void executeTask() {
+        withConnection(apiUrl) {
+            logger.quiet("Releasing $candidate $version...")
 
-            def values = [candidate: config.candidate, version: config.version]
+            def values = [candidate: candidate, version: version]
 
             def response = put(restClient, DEFAULT_ENDPOINT,
-                    config.consumerKey, config.consumerToken, values)
+                    consumerKey, consumerToken, values)
 
             logger.quiet("Response: ${response.statusCode}: ${response.contentAsString}...")
         }

--- a/src/main/groovy/net/gvmtool/vendors/GvmReleaseVersionTask.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/GvmReleaseVersionTask.groovy
@@ -1,24 +1,25 @@
 package net.gvmtool.vendors
 
-import net.gvmtool.vendors.model.GvmExtension
+import org.gradle.api.tasks.Input
 
 class GvmReleaseVersionTask extends GvmVendorBaseTask {
 
     static final RELEASE_ENDPOINT = "/release"
+
+    String downloadUrl
 
     GvmReleaseVersionTask() {
         description = "Release a new Candidate Version on GVM."
     }
 
     @Override
-    void execute(GvmExtension config) {
-        withConnection(config.api) {
-            logger.quiet("Releasing $config.candidate $config.version...")
+    void executeTask() {
+        withConnection(apiUrl) {
+            logger.quiet("Releasing $candidate $version...")
 
-            def values = [candidate: config.candidate, version: config.version, url: config.url]
+            def values = [candidate: candidate, version: version, url: downloadUrl]
 
-            def response = post(restClient, RELEASE_ENDPOINT,
-                    config.consumerKey, config.consumerToken, values)
+            def response = post(restClient, RELEASE_ENDPOINT, consumerKey, consumerToken, values)
 
             logger.quiet("Response: ${response.statusCode}: ${response.contentAsString}...")
         }

--- a/src/main/groovy/net/gvmtool/vendors/GvmVendorBaseTask.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/GvmVendorBaseTask.groovy
@@ -1,23 +1,31 @@
 package net.gvmtool.vendors
 
-import net.gvmtool.vendors.model.GvmExtension
 import net.gvmtool.vendors.validation.ConfigValidation
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.hibernate.validator.constraints.URL
+
+import javax.validation.constraints.NotNull
 
 abstract class GvmVendorBaseTask extends DefaultTask
         implements ExceptionHandling, HttpVerbs, ApiConnectivity, ConfigValidation {
 
+    @Input @URL @NotNull String apiUrl
+    @Input @NotNull String candidate
+    @Input @NotNull String version
+    @NotNull String consumerKey
+    @NotNull String consumerToken
+
     @TaskAction
     void start() {
-        GvmExtension config = project.gvm
         withTry(logger){
-            withValid(config){
-                execute(config)
+            withValid(this) {
+                executeTask()
             }
         }
     }
 
-    abstract void execute(GvmExtension config)
+    abstract void executeTask()
 
 }

--- a/src/main/groovy/net/gvmtool/vendors/GvmVendorPlugin.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/GvmVendorPlugin.groovy
@@ -3,17 +3,66 @@ package net.gvmtool.vendors
 import net.gvmtool.vendors.model.GvmExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 
 class GvmVendorPlugin implements Plugin<Project> {
     @Override
     void apply(Project target) {
         target.extensions.create("gvm", GvmExtension)
 
-        target.task 'gvmReleaseVersion', type: GvmReleaseVersionTask
-        target.task 'gvmDefaultVersion', type: GvmDefaultVersionTask
-        target.task 'gvmAnnounceVersion', type: GvmAnnounceVersionTask
+        configure(target.tasks.create('gvmReleaseVersion', GvmReleaseVersionTask))
 
-        target.task 'sdkMinorRelease', type: SdkMinorRelease
-        target.task 'sdkMajorRelease', type: SdkMajorRelease
+        configure(target.tasks.create('gvmDefaultVersion', GvmDefaultVersionTask))
+        configure(target.tasks.create('gvmAnnounceVersion', GvmAnnounceVersionTask))
+
+        configure(target.tasks.create('sdkMinorRelease', SdkMinorRelease))
+        configure(target.tasks.create('sdkMajorRelease', SdkMajorRelease))
+    }
+
+    private Task configureCommon(GvmVendorBaseTask task) {
+        configureTask(task) {
+            apiUrl = apiUrl ?: project.extensions.gvm.api
+            candidate = candidate ?: project.extensions.gvm.candidate
+            version = version ?: project.extensions.gvm.version
+            consumerKey = consumerKey ?: project.extensions.gvm.consumerKey
+            consumerToken = consumerToken ?: project.extensions.gvm.consumerToken
+        }
+        return task
+    }
+
+    private Task configure(GvmReleaseVersionTask task) {
+        configureCommon(task)
+        return configureTask(task) {
+            downloadUrl = downloadUrl ?: project.extensions.gvm.url
+        }
+    }
+
+    private Task configure(GvmDefaultVersionTask task) {
+        return configureCommon(task)
+    }
+
+    private Task configure(GvmAnnounceVersionTask task) {
+        configureCommon(task)
+        return configureTask(task) {
+            hashtag = hashtag ?: project.extensions.gvm.hashtag
+        }
+    }
+
+    private Task configure(SdkMinorRelease task) {
+        configureCommon(task)
+        return configureTask(task) {
+            downloadUrl = downloadUrl ?: project.extensions.gvm.url
+            hashtag = hashtag ?: project.extensions.gvm.hashtag
+        }
+    }
+
+    private Task configureTask(Task task, Closure initializer) {
+        task.project.afterEvaluate {
+            Closure cl = initializer.clone()
+            cl.delegate = task
+            cl.resolveStrategy = Closure.DELEGATE_FIRST
+            cl.call()
+        }
+        return task
     }
 }

--- a/src/main/groovy/net/gvmtool/vendors/SdkMajorRelease.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/SdkMajorRelease.groovy
@@ -1,7 +1,5 @@
 package net.gvmtool.vendors
 
-import net.gvmtool.vendors.model.GvmExtension
-
 class SdkMajorRelease extends SdkMinorRelease {
 
     static final DEFAULT_ENDPOINT = "/default"
@@ -11,12 +9,12 @@ class SdkMajorRelease extends SdkMinorRelease {
     }
 
     @Override
-    void execute(GvmExtension config) {
-        super.execute(config)
+    void executeTask() {
+        super.executeTask()
 
-        logger.quiet("Defaulting $config.candidate $config.version...")
-        def values = [candidate: config.candidate, version: config.version]
-        def response = put(restClient, DEFAULT_ENDPOINT, config.consumerKey, config.consumerToken, values)
+        logger.quiet("Defaulting $candidate $version...")
+        def values = [candidate: candidate, version: version]
+        def response = put(restClient, DEFAULT_ENDPOINT, consumerKey, consumerToken, values)
         logger.quiet("Response: ${response.statusCode}: ${response.contentAsString}...")
     }
 }

--- a/src/main/groovy/net/gvmtool/vendors/SdkMinorRelease.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/SdkMinorRelease.groovy
@@ -1,6 +1,6 @@
 package net.gvmtool.vendors
 
-import net.gvmtool.vendors.model.GvmExtension
+import org.gradle.api.tasks.Input
 
 class SdkMinorRelease extends GvmVendorBaseTask {
 
@@ -8,21 +8,24 @@ class SdkMinorRelease extends GvmVendorBaseTask {
 
     static final RELEASE_ENDPOINT = "/release"
 
+    String downloadUrl
+    String hashtag
+
     SdkMinorRelease() {
         description = "Convenience task performs a Minor Release consisting of Release and Announce combined."
     }
 
     @Override
-    void execute(GvmExtension config) {
-        withConnection(config.api) {
-            logger.quiet("Releasing $config.candidate $config.version...")
-            def releaseValues = [candidate: config.candidate, version: config.version, url: config.url]
-            def releaseResponse = post(restClient, RELEASE_ENDPOINT, config.consumerKey, config.consumerToken, releaseValues)
+    void executeTask() {
+        withConnection(apiUrl) {
+            logger.quiet("Releasing $candidate $version...")
+            def releaseValues = [candidate: candidate, version: version, url: downloadUrl]
+            def releaseResponse = post(restClient, RELEASE_ENDPOINT, consumerKey, consumerToken, releaseValues)
             logger.quiet("Response: ${releaseResponse.statusCode}: ${releaseResponse.contentAsString}...")
 
-            logger.quiet("Announcing for $config.candidate $config.version...")
-            def announceValues = [candidate: config.candidate, version: config.version, hashtag: config.hashtag ?: config.candidate]
-            def announceResponse = post(restClient, ANNOUNCE_ENDPOINT, config.consumerKey, config.consumerToken, announceValues)
+            logger.quiet("Announcing for $candidate $version...")
+            def announceValues = [candidate: candidate, version: version, hashtag: hashtag ?: candidate]
+            def announceResponse = post(restClient, ANNOUNCE_ENDPOINT, consumerKey, consumerToken, announceValues)
             logger.quiet("Response: ${announceResponse.statusCode}: ${announceResponse.contentAsString}...")
         }
     }

--- a/src/main/groovy/net/gvmtool/vendors/model/GvmExtension.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/model/GvmExtension.groovy
@@ -2,26 +2,19 @@ package net.gvmtool.vendors.model
 
 import org.hibernate.validator.constraints.URL
 
-import javax.validation.constraints.NotNull
-
 class GvmExtension {
 
     @URL
     String api = "https://vendor.gvmtool.net"
 
-    @NotNull
     String consumerKey
 
-    @NotNull
     String consumerToken
 
-    @NotNull
     String candidate
 
-    @NotNull
     String version
 
-    @NotNull
     @URL
     String url
 

--- a/src/main/groovy/net/gvmtool/vendors/validation/ConfigValidation.groovy
+++ b/src/main/groovy/net/gvmtool/vendors/validation/ConfigValidation.groovy
@@ -1,27 +1,25 @@
 package net.gvmtool.vendors.validation
 
-import net.gvmtool.vendors.model.GvmExtension
 import org.gradle.api.GradleException
+import org.gradle.api.Task
 
 import javax.validation.Validation
 import javax.validation.ValidatorFactory
 
 trait ConfigValidation {
 
-    final static GVM_CONFIG_BLOCK = "gvm"
-
     protected ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()
 
-    def withValid(GvmExtension config, fun) {
+    def withValid(Task task, fun) {
         def validator = validatorFactory.validator
-        detectViolationsIn(GVM_CONFIG_BLOCK, validator.validate(config))
+        detectViolationsIn(task.name, validator.validate(task))
         fun()
     }
 
-    def detectViolationsIn(String block, Set constraints) {
+    def detectViolationsIn(String name, Set constraints) {
         if (constraints.size()) {
             def message = constraints.collect { "${it.propertyPath} ${it.message}" }.join("; ")
-            throw new GradleException("config block invalid: $block - " + message)
+            throw new GradleException("Invalid configuration for task $name: " + message)
         }
     }
 }


### PR DESCRIPTION
Fixes issue #2. All the tasks now have properties that need to be initialised
before the tasks can be used. Instead of having the tasks pull the required
information from the GVM extension, the plugin class performs the binding
between the extension and task properties.

This means that users can define their own GVM task instances and they can
also configure the convention-based ones at any time before execution.
