### PR TITLE
Fix plugin coordinates for dependency declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It requires some configuration in the ```build.gradle``` file of the project.
 		}
 	  }
 	  dependencies {
-		classpath "gradle.plugin.io.sdkman:gradle-sdkvendor-plugin:2.0.0"
+		classpath "io.sdkman:gradle-sdkvendor-plugin:2.0.0"
 	  }
 	}
 


### PR DESCRIPTION
It seems like the coordinates for the plugin dependency changed in version 2.0.0.